### PR TITLE
Catch non-existent directory in pg_config

### DIFF
--- a/RPostgreSQL/configure
+++ b/RPostgreSQL/configure
@@ -2730,17 +2730,26 @@ fi
 ENABLE_LIBPQ=
 
 # If pg_config was found, let's use it
-if test "${PG_CONFIG}" != ""; then
+# Use pg_config for header and linker arguments
 
-    # Use pg_config for header and linker arguments
-    PG_INCDIR=`${PG_CONFIG} --includedir`
-    PG_LIBDIR=`${PG_CONFIG} --libdir`
+if test "${PG_CONFIG}" != "" ; then
+	PG_INCDIR=`${PG_CONFIG} --includedir`
+	PG_LIBDIR=`${PG_CONFIG} --libdir`
+fi
 
-else
 
+# If pg_config wasn't found, or was found but references a directory that doesn't exist,
+# let's look elsewhere
+
+if test "${PG_CONFIG}" == "" || ! test -d "${PG_INCDIR}" || ! test -d "${PG_LIBDIR}" ; then
     # let's look around -- code copied from RdbuiPgSQL but modified to use test -f
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PostgreSQL header files" >&5
 $as_echo "$as_me: checking for PostgreSQL header files" >&6;}
+
+    # Unset PG_INCDIR and PG_LIBDIR since at least one doesn't exist
+    PG_INCDIR=
+    PG_LIBDIR=
+
     if ! test $PG_INCDIR
     then
 	for dir in \
@@ -2753,6 +2762,8 @@ $as_echo "$as_me: checking for PostgreSQL header files" >&6;}
 	/usr/local/include/postgresql \
 	/usr/local/pgsql/include \
 	/usr/local/postgresql/include \
+	/usr/local/PostgreSQL/pg95/include \
+	~/Documents/PostgreSQL/pg95/include \
 	/opt/include \
 	/opt/include/pgsql \
 	/opt/include/postgresql \
@@ -2782,6 +2793,8 @@ $as_echo "$as_me: Checking include ${dir}." >&6;}
 	/usr/local/lib/postgresql \
 	/usr/local/pgsql/lib \
 	/usr/local/postgresql/lib \
+	/usr/local/PostgreSQL/pg95/lib \
+	~/Documents/PostgreSQL/pg95/lib \
 	/opt/lib \
 	/opt/lib/pgsql \
 	/opt/lib/postgresql \

--- a/RPostgreSQL/configure.in
+++ b/RPostgreSQL/configure.in
@@ -29,16 +29,27 @@ AC_PATH_PROG([PG_CONFIG], [pg_config])
 ENABLE_LIBPQ=
 
 # If pg_config was found, let's use it
-if test "${PG_CONFIG}" != ""; then
+# Use pg_config for header and linker arguments
 
-    # Use pg_config for header and linker arguments
-    PG_INCDIR=`${PG_CONFIG} --includedir`
-    PG_LIBDIR=`${PG_CONFIG} --libdir`
+if test "${PG_CONFIG}" != "" ; then
+        PG_INCDIR=`${PG_CONFIG} --includedir`
+        PG_LIBDIR=`${PG_CONFIG} --libdir`
+fi
 
-else
+
+# If pg_config wasn't found, or was found but references a directory that doesn't exist,
+# Let's look elsewhere
+
+if test "${PG_CONFIG}" == "" || ! test -d "${PG_INCDIR}" || ! test -d "${PG_LIBDIR}" ; then
 
     # let's look around -- code copied from RdbuiPgSQL but modified to use test -f
+
     AC_MSG_NOTICE([checking for PostgreSQL header files])
+
+    # Unset PG_INCDIR and PG_LIBDIR since at least one doesn't exist
+    PG_INCDIR=
+    PG_LIBDIR=
+
     if ! test $PG_INCDIR
     then
 	for dir in \
@@ -51,6 +62,8 @@ else
 	/usr/local/include/postgresql \
 	/usr/local/pgsql/include \
 	/usr/local/postgresql/include \
+	/usr/local/PostgreSQL/pg95/include \
+	~/Documents/PostgreSQL/pg95/include \
 	/opt/include \
 	/opt/include/pgsql \
 	/opt/include/postgresql \
@@ -79,6 +92,8 @@ else
 	/usr/local/lib/postgresql \
 	/usr/local/pgsql/lib \
 	/usr/local/postgresql/lib \
+	/usr/local/PostgreSQL/pg95/lib \
+	~/Documents/PostgreSQL/pg95/lib \
 	/opt/lib \
 	/opt/lib/pgsql \
 	/opt/lib/postgresql \


### PR DESCRIPTION
The configure scripts check pg_config to see if pg_config is set, but not whether --includedir and --libdir actually exist. If those directories are non-existent, the build fails. I added a check to see if those directories exist, and if not, unset the variables so the script will look in the paths specified in the script.

I also added the default path and /usr/local to the search path for the include and library locations in a BigSQL package install.
