### PR TITLE
bugfix: extract the correct variable if oldenc is a data.frame

### DIFF
--- a/RPostgreSQL/R/PostgreSQLSupport.R
+++ b/RPostgreSQL/R/PostgreSQLSupport.R
@@ -655,6 +655,9 @@ postgresqlWriteTable <- function(con, name, value, field.types, row.names = TRUE
         if(is.object(z) && !is.factor(z)) as.character(z) else z
     })
     oldenc <- dbGetQuery(new.con, "SHOW client_encoding")
+    if (inherits(oldenc, "data.frame")) {
+      oldenc <- oldenc$client_encoding
+    }
     postgresqlpqExec(new.con, "SET CLIENT_ENCODING TO 'UTF8'")
     sql4 <- paste("COPY", postgresqlTableRef(name),"(",paste(postgresqlQuoteId(names(value)),collapse=","),") FROM STDIN")
     postgresqlpqExec(new.con, sql4)


### PR DESCRIPTION
 When `oldenc <- dbGetQuery(new.con, "SHOW client_encoding")` returns a data.frame, `sql5 <- paste("SET CLIENT_ENCODING TO '", oldenc, "'", sep="")` returns the error below

```
Error in paste("SET CLIENT_ENCODING TO '", oldenc, "'", sep = "") : 
   non-string argument to internal 'paste'
```

This pull request converts `oldenc` to a character when it is a data.frame.
