### PR TITLE
let dbSendQuery raise error if needed; return all cols for 0-row results

### DIFF
--- a/RPostgreSQL/R/PostgreSQLSupport.R
+++ b/RPostgreSQL/R/PostgreSQLSupport.R
@@ -270,11 +270,11 @@ postgresqlQuickSQL <- function(con, statement, ...) {
     if (length(rsList)>0){  # clear results
         dbClearResult(rsList[[1]])
     }
-    rs <- try(dbSendQuery(con, statement, ...))
-    if (inherits(rs, ErrorClass)){
-        warning("Could not create execute: ", statement)
-        return(NULL)
-    }
+
+    ## Let dbSendQuery raise an error if it cannot execute statement.
+    ## (Surrounding code should be responsible for handling errors.)
+    rs <- dbSendQuery(con, statement, ...)
+
     if(dbHasCompleted(rs)){
         dbClearResult(rs)            ## no records to fetch, we're done
         invisible()
@@ -421,8 +421,7 @@ postgresqlFetch <- function(res, n=0, ...) {
     n <- as(n, "integer")
     rsId <- as(res, "integer")
     rel <- .Call(RS_PostgreSQL_fetch, rsId, nrec = n)
-    if(length(rel)==0 || length(rel[[1]])==0)
-        return(NULL)
+
     ## create running row index as of previous fetch (if any)
     cnt <- dbGetRowCount(res)
     nrec <- length(rel[[1]])


### PR DESCRIPTION
Two issues in this PR:

(1) Data frames returned by `fetch` should be 0 x n, not 0 x 0, when having zero rows.

Existing behavior:
```R
!> dbGetQuery(conn, "SELECT col_1, col_2 FROM my_table LIMIT 0")
 data frame with 0 columns and 0 rows
```
New behavior:
```R
!> dbGetQuery(conn, "SELECT col_1, col_2 FROM my_table LIMIT 0")
 [1] col_1 col_2
 <0 rows> (or 0-length row.names)
```
This allows for seamless `rbind`-ing when piecing together tables, and prevents column access errors on the returned data frame when the query results happen to have zero rows.

(2) `postgresqlQuickSQL` is returning `NULL` (with a warning) on error-ing statements.
The calling code should be responsible for handling raised conditions (e.g. with a tryCatch block), otherwise scripts running non-interactively won't fail-fast.

Existing behavior (no error raised):
```R
  > x <- dbGetQuery(conn, "SELECTT * FROM my_table")
 Error in postgresqlExecStatement(conn, statement, ...) :
   RS-DBI driver: (could not Retrieve the result : ERROR:  syntax error at or near "SELECTT"
 LINE 1: SELECTT * FROM my_table
         ^
 )
 Warning message:
 In postgresqlQuickSQL(conn, statement, ...) :
   Could not create execute: SELECTT * FROM my_table
 > str(x)
  NULL
```
New behavior (error raised):
```R
 > x <- dbGetQuery(conn, "SELECTT * FROM my_table")
 Error in postgresqlExecStatement(conn, statement, ...) :
   RS-DBI driver: (could not Retrieve the result : ERROR:  syntax error at or near "SELECTT"
 LINE 1: SELECTT * FROM my_table
         ^
 )
!> str(x)
 Error in str(x) : object 'x' not found
```
