### PR TITLE
Crash with RS_DBI_errorMessage

### DIFF
--- a/RPostgreSQL/src/RS-DBI.c
+++ b/RPostgreSQL/src/RS-DBI.c
@@ -597,16 +597,16 @@ RS_DBI_errorMessage(char *msg, DBI_EXCEPTION exception_type)
 
     switch (exception_type) {
     case RS_DBI_MESSAGE:
-        Rf_warning("%s driver message: (%s)", driver);    /* was PRINT_IT */
+        Rf_warning("%s driver message: (%s)", driver, msg);    /* was PRINT_IT */
         break;
     case RS_DBI_WARNING:
-        Rf_warning("%s driver warning: (%s)", driver);
+        Rf_warning("%s driver warning: (%s)", driver, msg);
         break;
     case RS_DBI_ERROR:
-        Rf_error("%s driver: (%s)", driver);
+        Rf_error("%s driver: (%s)", driver, msg);
         break;
     case RS_DBI_TERMINATE:
-        Rf_error("%s driver fatal: (%s)", driver);     /* was TERMINATE */
+        Rf_error("%s driver fatal: (%s)", driver, msg);     /* was TERMINATE */
         break;
     }
     return;


### PR DESCRIPTION
The msg argument is missing for the second specifier. It causes crash
like:

 *** caught segfault ***
address 0x4, cause 'memory not mapped'

Reported through https://github.com/greenplum-db/PivotalR/issues/61
