### PR TITLE
Use libpq from the system (Rtools).

### DIFF
--- a/RPostgreSQL/src/Makevars.win
+++ b/RPostgreSQL/src/Makevars.win
@@ -1,11 +1,8 @@
-PKG_CPPFLAGS=-I./libpq
-PKG_LIBS=libpq/libpq.a -lshfolder -lwsock32 -lws2_32 -lsecur32
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lm -lz -lsecur32 -lws2_32 -lwldap32 \
+             -lshell32 -lcrypt32 -lgdi32
+else
+  PKG_CPPFLAGS = $(shell pkg-config --cflags libpq)
+  PKG_LIBS = $(shell pkg-config --libs libpq)
+endif
 
-.PHONY: all 
-all:  $(SHLIB)
-$(SHLIB): libpq/libpq.a
-
-export CC
-
-libpq/libpq.a:
-	(cd libpq; make CUSTOM_CC="$(CC)" -f "$(R_HOME)/etc/$(R_ARCH)/Makeconf" -f Makefile.win)


### PR DESCRIPTION
This patch switches to the system-provided libpq on Windows, found via pkg-config if available, or via a hard-coded library list. I've tested this with Rtools42, 3, 4 and 5 (which all have libpq).

Using the system-provided libpq has the advantage that one avoids a warning about disallowed external symbols (now displayed on the CRAN check results for the package). Also, it is the preferred way on CRAN - use the system-provided library, and only if not feasible, possible a bundled version. Also, Rtools 43,44 and 45 have a version of libpq that is no longer subject to CVE-2025-1094.