### PR TITLE
Add libpq within a DESCRIPTION.SystemRequirements

### DIFF
--- a/RPostgreSQL/DESCRIPTION
+++ b/RPostgreSQL/DESCRIPTION
@@ -38,6 +38,7 @@ Authors@R: c(person(given = "Joe",
                        family = "Tiffin",
                        role = "aut"))
 NeedsCompilation: yes
+SystemRequirements: libpq
 Packaged: 2025-03-28 01:35:52 UTC; tomoaki
 Author: Joe Conway [aut],
   Dirk Eddelbuettel [aut],


### PR DESCRIPTION
Add libpq within a DESCRIPTION.SystemRequirements entry to provide tools a chance to discover RPostgreSQL has a system dependency, and to suggest the OS specific packages to install; for instance the `renv` dependency manager.

Some references to this usage in the community:

* https://r-pkgs.org/description.html#other-fields
* https://rstudio.github.io/renv/reference/sysreqs.html (See *Details* section)

Example specification in a package: https://crandb.r-pkg.org/igraph

I'm new to the R community and have mainly been focused on packaging R apps in various forms, so I'm sensitive to the quagmire that is the R communities' OS dependency woes. I also see a number of issues against this repository about a failure to have `libpq` installed, so hopefully this addition can help the tool-chains do the needful.

I'm not sure how tightly this R package is tied to the `libpq` versions, but if there is a desire to notate a version, I'm happy to add; e.g. `(>= 10)` or 14, or?